### PR TITLE
Update chokidar to ^3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "anymatch": "^2.0.0",
     "browserify": "^16.1.0",
-    "chokidar": "^2.1.1",
+    "chokidar": "^3.2.1",
     "defined": "^1.0.0",
     "outpipe": "^1.1.0",
     "through2": "^2.0.0",


### PR DESCRIPTION
Older versions of Chokidar have a few issues watching large amounts of files (as in no events are triggered on file changes after a while).